### PR TITLE
fix(cmd): silence help text on runtime errors

### DIFF
--- a/cmd/azure/main.go
+++ b/cmd/azure/main.go
@@ -35,6 +35,7 @@ func buildRootCommand(in io.Reader) (*cobra.Command, error) {
 			m.Out = cmd.OutOrStdout()
 			m.Err = cmd.OutOrStderr()
 		},
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().BoolVar(&m.Debug, "debug", false, "Enable debug logging")


### PR DESCRIPTION
Don't print help text on runtime errors.

Ref https://github.com/deislabs/porter-helm/pull/27